### PR TITLE
test: make minis3.go coverage 100%

### DIFF
--- a/minis3.go
+++ b/minis3.go
@@ -11,6 +11,11 @@ import (
 	"github.com/yashikota/minis3/internal/handler"
 )
 
+var (
+	listenFn = net.Listen
+	fatalFn  = log.Fatalln
+)
+
 // Minis3 is the main server struct.
 type Minis3 struct {
 	mu       sync.Mutex
@@ -42,7 +47,7 @@ func (m *Minis3) Start() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	l, err := listenFn("tcp", "127.0.0.1:0")
 	if err != nil {
 		return errors.New("failed to listen: " + err.Error())
 	}
@@ -54,7 +59,7 @@ func (m *Minis3) Start() error {
 
 	go func() {
 		if err := m.server.Serve(l); err != nil && err != http.ErrServerClosed {
-			log.Fatalln("minis3 server error:", err)
+			fatalFn("minis3 server error:", err)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- add test seams for listener and fatal logger in minis3 server startup
- add tests for Run/Start/Close/Addr/Host success and error paths
- cover server serve-error branch without terminating test process

## Verification
- go test -count=1 ./...
- go test -coverprofile=/tmp/minis3-go-main.cov ./...
- go tool cover -func=/tmp/minis3-go-main.cov | rg 'minis3.go'