### PR TITLE
chore: add s3-tests badge with pass/fail counts

### DIFF
--- a/.github/badges/s3-tests.json
+++ b/.github/badges/s3-tests.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "s3-tests",
+  "message": "success n/a, fail n/a, skip n/a, error n/a",
+  "color": "lightgrey"
+}

--- a/.github/workflows/s3tests.yaml
+++ b/.github/workflows/s3tests.yaml
@@ -6,6 +6,13 @@ on:
       - "**.go"
       - "integration/s3-test/**"
       - ".github/workflows/s3tests.yaml"
+  push:
+    branches:
+      - main
+    paths:
+      - "**.go"
+      - "integration/s3-test/**"
+      - ".github/workflows/s3tests.yaml"
   workflow_dispatch:
 
 jobs:
@@ -15,6 +22,12 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    outputs:
+      has_results: ${{ steps.summary.outputs.has_results }}
+      passed: ${{ steps.summary.outputs.passed }}
+      failed: ${{ steps.summary.outputs.failed }}
+      skipped: ${{ steps.summary.outputs.skipped }}
+      errors: ${{ steps.summary.outputs.errors }}
 
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
@@ -41,15 +54,18 @@ jobs:
         run: |
           if [ ! -f s3-test.log ]; then
             echo "s3-test.log not found"
+            echo "has_results=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          result_line=$(grep -oE '[0-9]+ failed, [0-9]+ passed, [0-9]+ skipped' s3-test.log | tail -1)
+          result_line=$(grep -oE '[0-9]+ failed, [0-9]+ passed, [0-9]+ skipped(, [0-9]+ errors?)?' s3-test.log | tail -1)
           if [ -n "$result_line" ]; then
-            failed=$(echo "$result_line" | cut -d' ' -f1)
-            passed=$(echo "$result_line" | cut -d' ' -f3)
-            skipped=$(echo "$result_line" | cut -d' ' -f5)
-            total=$((passed + failed))
+            failed=$(echo "$result_line" | awk '{print $1}')
+            passed=$(echo "$result_line" | awk '{print $3}')
+            skipped=$(echo "$result_line" | awk '{print $5}')
+            errors=$(echo "$result_line" | awk '{print $7}')
+            errors=${errors:-0}
+            total=$((passed + failed + errors))
             if [ "$total" -gt 0 ]; then
               pass_rate=$(echo "scale=2; $passed * 100 / $total" | bc)
             else
@@ -59,6 +75,7 @@ jobs:
             echo "passed=$passed" >> $GITHUB_OUTPUT
             echo "failed=$failed" >> $GITHUB_OUTPUT
             echo "skipped=$skipped" >> $GITHUB_OUTPUT
+            echo "errors=$errors" >> $GITHUB_OUTPUT
             echo "pass_rate=$pass_rate" >> $GITHUB_OUTPUT
             echo "has_results=true" >> $GITHUB_OUTPUT
           else
@@ -73,6 +90,7 @@ jobs:
             const passed = '${{ steps.summary.outputs.passed }}';
             const failed = '${{ steps.summary.outputs.failed }}';
             const skipped = '${{ steps.summary.outputs.skipped }}';
+            const errors = '${{ steps.summary.outputs.errors }}';
             const passRate = '${{ steps.summary.outputs.pass_rate }}';
 
             const body = `## S3 Test Summary
@@ -82,6 +100,7 @@ jobs:
             | Passed | ${passed} |
             | Failed | ${failed} |
             | Skipped | ${skipped} |
+            | Errors | ${errors} |
             | **Pass Rate** | **${passRate}%** |
 
             <details>
@@ -117,3 +136,51 @@ jobs:
                 body: body
               });
             }
+
+  publish-badge:
+    needs: s3-tests
+    if: needs.s3-tests.outputs.has_results == 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Build badge payload
+        run: |
+          passed='${{ needs.s3-tests.outputs.passed }}'
+          failed='${{ needs.s3-tests.outputs.failed }}'
+          skipped='${{ needs.s3-tests.outputs.skipped }}'
+          errors='${{ needs.s3-tests.outputs.errors }}'
+
+          if [ "$failed" -eq 0 ] && [ "$errors" -eq 0 ]; then
+            color="brightgreen"
+          elif [ "$passed" -gt 0 ]; then
+            color="yellow"
+          else
+            color="red"
+          fi
+
+          mkdir -p .github/badges
+          cat > .github/badges/s3-tests.json <<EOF
+          {
+            "schemaVersion": 1,
+            "label": "s3-tests",
+            "message": "success ${passed}, fail ${failed}, skip ${skipped}, error ${errors}",
+            "color": "${color}"
+          }
+          EOF
+
+      - name: Update badge data
+        run: |
+          if git diff --quiet -- .github/badges/s3-tests.json; then
+            echo "No badge changes"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/s3-tests.json
+          git commit -m "chore: update s3-test badge data"
+          git push origin HEAD:${GITHUB_REF_NAME}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Minis3 🪣
 
 [![codecov](https://codecov.io/gh/yashikota/minis3/graph/badge.svg?token=16VPV4FWZE)](https://codecov.io/gh/yashikota/minis3)
+[![s3-tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/yashikota/minis3/main/.github/badges/s3-tests.json&cacheSeconds=300)](https://github.com/yashikota/minis3/actions/workflows/s3tests.yaml)
 
 Sometimes you want to test code which uses S3, without making it a full-blown integration test. Minis3 implements (parts of) the S3 server, to be used in unittests. It enables a simple, cheap, in-memory, S3 replacement, with a real TCP interface. Think of it as the S3 version of `net/http/httptest`
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -52,7 +52,7 @@ tasks:
           echo "Error: s3-test.log not found. Run 'task s3-test' first."
           exit 1
         fi
-        result_line=$(rg -o '\d+ failed, \d+ passed, \d+ skipped' s3-test.log | tail -1)
+        result_line=$(rg -o '\d+ failed, \d+ passed, \d+ skipped(, \d+ errors?)?' s3-test.log | tail -1)
         if [ -n "$result_line" ]; then
           echo ""
           echo "=========================================="
@@ -63,18 +63,21 @@ tasks:
           failed=$(echo "$result_line" | cut -d' ' -f1)
           passed=$(echo "$result_line" | cut -d' ' -f3)
           skipped=$(echo "$result_line" | cut -d' ' -f5)
+          errors=$(echo "$result_line" | cut -d' ' -f7)
 
           passed=${passed:-0}
           failed=${failed:-0}
           skipped=${skipped:-0}
+          errors=${errors:-0}
 
-          total=$((passed + failed))
+          total=$((passed + failed + errors))
           if [ "$total" -gt 0 ]; then
             pass_rate=$(echo "scale=2; $passed * 100 / $total" | bc)
             echo ""
             echo "Passed:  $passed"
             echo "Failed:  $failed"
             echo "Skipped: $skipped"
+            echo "Errors:  $errors"
             echo ""
             echo "Pass Rate: ${pass_rate}% ($passed/$total)"
           fi


### PR DESCRIPTION
## Summary
- add an s3-tests badge to README using img.shields.io/endpoint
- add badge payload file .github/badges/s3-tests.json (initial n/a values)
- update .github/workflows/s3tests.yaml to parse failed/passed/skipped/errors and include Errors in PR comment
- add a publish-badge job that updates .github/badges/s3-tests.json on main pushes
- update task s3-test-summary to parse and print errors

## Impacted S3 operations
- no S3 API behavior changes (docs/CI only)

## Validation
- go test -count=1 ./...
