### PR TITLE
fix: handle variable pytest summary formats in s3-test parsing

### DIFF
--- a/.github/workflows/s3tests.yaml
+++ b/.github/workflows/s3tests.yaml
@@ -58,13 +58,12 @@ jobs:
             exit 0
           fi
 
-          result_line=$(grep -oE '[0-9]+ failed, [0-9]+ passed, [0-9]+ skipped(, [0-9]+ errors?)?' s3-test.log | tail -1)
+          result_line=$(grep -oE '[0-9]+ (failed|passed|skipped|deselected|warnings?|errors?)(, [0-9]+ (failed|passed|skipped|deselected|warnings?|errors?))*' s3-test.log | tail -1)
           if [ -n "$result_line" ]; then
-            failed=$(echo "$result_line" | awk '{print $1}')
-            passed=$(echo "$result_line" | awk '{print $3}')
-            skipped=$(echo "$result_line" | awk '{print $5}')
-            errors=$(echo "$result_line" | awk '{print $7}')
-            errors=${errors:-0}
+            failed=$(echo "$result_line" | grep -oE '[0-9]+ failed' | grep -oE '[0-9]+' || echo 0)
+            passed=$(echo "$result_line" | grep -oE '[0-9]+ passed' | grep -oE '[0-9]+' || echo 0)
+            skipped=$(echo "$result_line" | grep -oE '[0-9]+ skipped' | grep -oE '[0-9]+' || echo 0)
+            errors=$(echo "$result_line" | grep -oE '[0-9]+ errors?' | grep -oE '[0-9]+' || echo 0)
             total=$((passed + failed + errors))
             if [ "$total" -gt 0 ]; then
               pass_rate=$(echo "scale=2; $passed * 100 / $total" | bc)

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -52,7 +52,7 @@ tasks:
           echo "Error: s3-test.log not found. Run 'task s3-test' first."
           exit 1
         fi
-        result_line=$(rg -o '\d+ failed, \d+ passed, \d+ skipped(, \d+ errors?)?' s3-test.log | tail -1)
+        result_line=$(rg -o '\d+ (failed|passed|skipped|deselected|warnings?|errors?)(, \d+ (failed|passed|skipped|deselected|warnings?|errors?))*' s3-test.log | tail -1)
         if [ -n "$result_line" ]; then
           echo ""
           echo "=========================================="
@@ -60,10 +60,10 @@ tasks:
           echo "=========================================="
 
           # Parse numbers
-          failed=$(echo "$result_line" | cut -d' ' -f1)
-          passed=$(echo "$result_line" | cut -d' ' -f3)
-          skipped=$(echo "$result_line" | cut -d' ' -f5)
-          errors=$(echo "$result_line" | cut -d' ' -f7)
+          failed=$(echo "$result_line" | rg -o '\d+ failed' | rg -o '\d+' || echo 0)
+          passed=$(echo "$result_line" | rg -o '\d+ passed' | rg -o '\d+' || echo 0)
+          skipped=$(echo "$result_line" | rg -o '\d+ skipped' | rg -o '\d+' || echo 0)
+          errors=$(echo "$result_line" | rg -o '\d+ errors?' | rg -o '\d+' || echo 0)
 
           passed=${passed:-0}
           failed=${failed:-0}


### PR DESCRIPTION
## Summary

- pytest はゼロ件のカテゴリ（`failed`, `skipped` 等）を出力に含めないが、既存の正規表現は `N failed, N passed, N skipped` が全て揃っていることを前提にしていた
- カテゴリが1つでも欠けると `has_results=false` になり、PR コメント投稿と badge データコミットが両方スキップされていた
- 検出 regex を全 pytest カテゴリ対応に変更し、各メトリクスの抽出を位置ベース（`awk`/`cut`）からキーワードベース（個別 `grep`/`rg`）に修正

### 対象ファイル
- `.github/workflows/s3tests.yaml` — Generate summary ステップ
- `taskfile.yaml` — s3-test-summary タスク

### 修正前にマッチしなかった実際の出力例

| Run | pytest 出力 |
|-----|------------|
| PR #22 (全テストパス) | `1406 passed, 84 skipped, 2 deselected, 3 warnings` |
| main (61b1ab2) | `63 failed, 585 passed, 2 deselected, 15 warnings, 845 errors` |
| main (2fcde4b) | `80 failed, 563 passed, 15 warnings, 853 errors` |

## Test plan

- [ ] PR 上で S3 Tests ワークフローが実行され、PR コメントが投稿されることを確認
- [ ] main マージ後に publish-badge ジョブが実行され、badge データがコミットされることを確認