### PR TITLE
feat: enhance IAM user and access key management

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -54,4 +54,6 @@ jobs:
             aqua_version: v2.55.2
 
       - name: Run test
-        run: task test
+        run: |
+          task unit-test &&
+          task sdk-test

--- a/internal/backend/bucket.go
+++ b/internal/backend/bucket.go
@@ -416,7 +416,7 @@ func (b *Backend) GetBucketPolicy(bucketName string) (string, error) {
 }
 
 // PutBucketPolicy sets the bucket policy.
-func (b *Backend) PutBucketPolicy(bucketName, policy string) error {
+func (b *Backend) PutBucketPolicy(bucketName, policy string, denySelfAccess bool) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -434,6 +434,7 @@ func (b *Backend) PutBucketPolicy(bucketName, policy string) error {
 	}
 
 	bucket.Policy = policy
+	bucket.PolicyDenySelfAccess = denySelfAccess
 	return nil
 }
 
@@ -448,6 +449,7 @@ func (b *Backend) DeleteBucketPolicy(bucketName string) error {
 	}
 
 	bucket.Policy = ""
+	bucket.PolicyDenySelfAccess = false
 	return nil
 }
 

--- a/internal/backend/bucket_additional_test.go
+++ b/internal/backend/bucket_additional_test.go
@@ -892,7 +892,7 @@ func TestPutBucketPolicyRejectsAllowNotPrincipal(t *testing.T) {
 	}
 
 	invalid := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","NotPrincipal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::policy-notprincipal/*"}]}`
-	if err := b.PutBucketPolicy("policy-notprincipal", invalid); !errors.Is(
+	if err := b.PutBucketPolicy("policy-notprincipal", invalid, false); !errors.Is(
 		err,
 		ErrMalformedPolicy,
 	) {
@@ -900,7 +900,7 @@ func TestPutBucketPolicyRejectsAllowNotPrincipal(t *testing.T) {
 	}
 
 	valid := `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","NotPrincipal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::policy-notprincipal/*"}]}`
-	if err := b.PutBucketPolicy("policy-notprincipal", valid); err != nil {
+	if err := b.PutBucketPolicy("policy-notprincipal", valid, false); err != nil {
 		t.Fatalf("PutBucketPolicy deny-notprincipal failed: %v", err)
 	}
 }

--- a/internal/backend/bucket_branch_test.go
+++ b/internal/backend/bucket_branch_test.go
@@ -24,7 +24,7 @@ func TestBucketBranchCoverage(t *testing.T) {
 		if err := b.DeleteBucketTagging("missing"); !errors.Is(err, ErrBucketNotFound) {
 			t.Fatalf("expected ErrBucketNotFound from DeleteBucketTagging, got %v", err)
 		}
-		if err := b.PutBucketPolicy("missing", `{"Version":"2012-10-17","Statement":[]}`); !errors.Is(
+		if err := b.PutBucketPolicy("missing", `{"Version":"2012-10-17","Statement":[]}`, false); !errors.Is(
 			err,
 			ErrBucketNotFound,
 		) {

--- a/internal/backend/bucket_test.go
+++ b/internal/backend/bucket_test.go
@@ -192,7 +192,7 @@ func TestBucketPolicy(t *testing.T) {
 	})
 
 	t.Run("put valid policy", func(t *testing.T) {
-		err := b.PutBucketPolicy("test-bucket", validPolicy)
+		err := b.PutBucketPolicy("test-bucket", validPolicy, false)
 		if err != nil {
 			t.Fatalf("PutBucketPolicy failed: %v", err)
 		}
@@ -208,7 +208,7 @@ func TestBucketPolicy(t *testing.T) {
 	})
 
 	t.Run("put invalid policy", func(t *testing.T) {
-		err := b.PutBucketPolicy("test-bucket", invalidPolicy)
+		err := b.PutBucketPolicy("test-bucket", invalidPolicy, false)
 		if !errors.Is(err, ErrMalformedPolicy) {
 			t.Errorf("expected ErrMalformedPolicy, got %v", err)
 		}
@@ -216,7 +216,7 @@ func TestBucketPolicy(t *testing.T) {
 
 	t.Run("delete policy", func(t *testing.T) {
 		// First set a valid policy
-		_ = b.PutBucketPolicy("test-bucket", validPolicy)
+		_ = b.PutBucketPolicy("test-bucket", validPolicy, false)
 
 		err := b.DeleteBucketPolicy("test-bucket")
 		if err != nil {

--- a/internal/backend/iam_test.go
+++ b/internal/backend/iam_test.go
@@ -1,0 +1,193 @@
+package backend
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestIAMUserCRUD(t *testing.T) {
+	b := New()
+
+	t.Run("create user", func(t *testing.T) {
+		user, err := b.CreateIAMUser("alice", "/test/")
+		if err != nil {
+			t.Fatalf("CreateIAMUser failed: %v", err)
+		}
+		if user.UserName != "alice" {
+			t.Fatalf("UserName = %q, want alice", user.UserName)
+		}
+		if user.Path != "/test/" {
+			t.Fatalf("Path = %q, want /test/", user.Path)
+		}
+		if !strings.HasPrefix(user.UserID, "AID") {
+			t.Fatalf("UserID should start with AID, got %q", user.UserID)
+		}
+		if !strings.Contains(user.Arn, "alice") {
+			t.Fatalf("Arn should contain alice, got %q", user.Arn)
+		}
+	})
+
+	t.Run("create duplicate user", func(t *testing.T) {
+		_, err := b.CreateIAMUser("alice", "/test/")
+		if !errors.Is(err, ErrIAMUserAlreadyExists) {
+			t.Fatalf("expected ErrIAMUserAlreadyExists, got %v", err)
+		}
+	})
+
+	t.Run("list users", func(t *testing.T) {
+		_, _ = b.CreateIAMUser("bob", "/other/")
+		users := b.ListIAMUsers("")
+		if len(users) != 2 {
+			t.Fatalf("expected 2 users, got %d", len(users))
+		}
+
+		users = b.ListIAMUsers("/test/")
+		if len(users) != 1 || users[0].UserName != "alice" {
+			t.Fatalf("expected 1 user alice with /test/ prefix, got %v", users)
+		}
+	})
+
+	t.Run("delete user", func(t *testing.T) {
+		err := b.DeleteIAMUser("alice")
+		if err != nil {
+			t.Fatalf("DeleteIAMUser failed: %v", err)
+		}
+
+		users := b.ListIAMUsers("")
+		if len(users) != 1 {
+			t.Fatalf("expected 1 user after delete, got %d", len(users))
+		}
+	})
+
+	t.Run("delete nonexistent user", func(t *testing.T) {
+		err := b.DeleteIAMUser("nonexistent")
+		if !errors.Is(err, ErrIAMUserNotFound) {
+			t.Fatalf("expected ErrIAMUserNotFound, got %v", err)
+		}
+	})
+}
+
+func TestIAMAccessKeyCRUD(t *testing.T) {
+	b := New()
+	_, _ = b.CreateIAMUser("testuser", "/")
+
+	t.Run("create access key", func(t *testing.T) {
+		key, err := b.CreateIAMAccessKey("testuser")
+		if err != nil {
+			t.Fatalf("CreateIAMAccessKey failed: %v", err)
+		}
+		if key.UserName != "testuser" {
+			t.Fatalf("UserName = %q, want testuser", key.UserName)
+		}
+		if !strings.HasPrefix(key.AccessKeyId, "AKIA") {
+			t.Fatalf("AccessKeyId should start with AKIA, got %q", key.AccessKeyId)
+		}
+		if key.SecretAccessKey == "" {
+			t.Fatal("SecretAccessKey should not be empty")
+		}
+		if key.Status != "Active" {
+			t.Fatalf("Status = %q, want Active", key.Status)
+		}
+	})
+
+	t.Run("create access key for nonexistent user", func(t *testing.T) {
+		_, err := b.CreateIAMAccessKey("nonexistent")
+		if !errors.Is(err, ErrIAMUserNotFound) {
+			t.Fatalf("expected ErrIAMUserNotFound, got %v", err)
+		}
+	})
+
+	t.Run("list access keys", func(t *testing.T) {
+		keys := b.ListIAMAccessKeys("testuser")
+		if len(keys) != 1 {
+			t.Fatalf("expected 1 key, got %d", len(keys))
+		}
+	})
+
+	t.Run("lookup credential", func(t *testing.T) {
+		keys := b.ListIAMAccessKeys("testuser")
+		secret, ok := b.LookupCredential(keys[0].AccessKeyId)
+		if !ok {
+			t.Fatal("LookupCredential should find dynamic key")
+		}
+		if secret != keys[0].SecretAccessKey {
+			t.Fatalf("secret mismatch")
+		}
+
+		_, ok = b.LookupCredential("nonexistent-key")
+		if ok {
+			t.Fatal("LookupCredential should not find nonexistent key")
+		}
+	})
+
+	t.Run("delete access key", func(t *testing.T) {
+		keys := b.ListIAMAccessKeys("testuser")
+		err := b.DeleteIAMAccessKey("testuser", keys[0].AccessKeyId)
+		if err != nil {
+			t.Fatalf("DeleteIAMAccessKey failed: %v", err)
+		}
+
+		keys = b.ListIAMAccessKeys("testuser")
+		if len(keys) != 0 {
+			t.Fatalf("expected 0 keys after delete, got %d", len(keys))
+		}
+	})
+
+	t.Run("delete nonexistent access key", func(t *testing.T) {
+		err := b.DeleteIAMAccessKey("testuser", "AKIANOTEXIST")
+		if !errors.Is(err, ErrIAMAccessKeyNotFound) {
+			t.Fatalf("expected ErrIAMAccessKeyNotFound, got %v", err)
+		}
+	})
+
+	t.Run("delete user cleans up keys", func(t *testing.T) {
+		_, _ = b.CreateIAMAccessKey("testuser")
+		_, _ = b.CreateIAMAccessKey("testuser")
+		keys := b.ListIAMAccessKeys("testuser")
+		if len(keys) != 2 {
+			t.Fatalf("expected 2 keys, got %d", len(keys))
+		}
+
+		_ = b.DeleteIAMUser("testuser")
+
+		// Keys should no longer be lookup-able
+		for _, k := range keys {
+			if _, ok := b.LookupCredential(k.AccessKeyId); ok {
+				t.Fatalf("key %q should have been cleaned up", k.AccessKeyId)
+			}
+		}
+	})
+}
+
+func TestPutBucketPolicyDenySelfAccess(t *testing.T) {
+	b := New()
+	_ = b.CreateBucket("test-bucket")
+
+	policy := `{"Version":"2012-10-17","Statement":[]}`
+
+	t.Run("default denySelfAccess is false", func(t *testing.T) {
+		_ = b.PutBucketPolicy("test-bucket", policy, false)
+		bucket, _ := b.GetBucket("test-bucket")
+		if bucket.PolicyDenySelfAccess {
+			t.Fatal("PolicyDenySelfAccess should be false")
+		}
+	})
+
+	t.Run("denySelfAccess set to true", func(t *testing.T) {
+		_ = b.PutBucketPolicy("test-bucket", policy, true)
+		bucket, _ := b.GetBucket("test-bucket")
+		if !bucket.PolicyDenySelfAccess {
+			t.Fatal("PolicyDenySelfAccess should be true")
+		}
+	})
+
+	t.Run("delete policy resets denySelfAccess", func(t *testing.T) {
+		_ = b.PutBucketPolicy("test-bucket", policy, true)
+		_ = b.DeleteBucketPolicy("test-bucket")
+		bucket, _ := b.GetBucket("test-bucket")
+		if bucket.PolicyDenySelfAccess {
+			t.Fatal("PolicyDenySelfAccess should be false after delete")
+		}
+	})
+}

--- a/internal/handler/access_control_deep_branches_test.go
+++ b/internal/handler/access_control_deep_branches_test.go
@@ -74,7 +74,7 @@ func TestCheckAccessAdditionalBranches(t *testing.T) {
 
 	t.Run("restrict public buckets blocks non-owner even with public policy", func(t *testing.T) {
 		policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Principal":"*","Resource":"arn:aws:s3:::access-branch/*"}]}`
-		if err := b.PutBucketPolicy("access-branch", policy); err != nil {
+		if err := b.PutBucketPolicy("access-branch", policy, false); err != nil {
 			t.Fatalf("PutBucketPolicy failed: %v", err)
 		}
 		if err := b.PutPublicAccessBlock(
@@ -154,7 +154,7 @@ func TestCheckAccessWithContextAdditionalBranches(t *testing.T) {
 
 	t.Run("explicit deny is rejected", func(t *testing.T) {
 		policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"s3:ListBucket","Principal":"*","Resource":"arn:aws:s3:::ctx-branch"}]}`
-		if err := b.PutBucketPolicy("ctx-branch", policy); err != nil {
+		if err := b.PutBucketPolicy("ctx-branch", policy, false); err != nil {
 			t.Fatalf("PutBucketPolicy failed: %v", err)
 		}
 

--- a/internal/handler/aws_spec_compat_test.go
+++ b/internal/handler/aws_spec_compat_test.go
@@ -132,7 +132,7 @@ func TestGetBucketLocationAccessControl(t *testing.T) {
 		policy := `{"Version":"2012-10-17","Statement":[` +
 			`{"Effect":"Allow","Principal":"*","Action":"s3:GetBucketLocation",` +
 			`"Resource":"arn:aws:s3:::location-auth-bucket"}]}`
-		if err := b.PutBucketPolicy("location-auth-bucket", policy); err != nil {
+		if err := b.PutBucketPolicy("location-auth-bucket", policy, false); err != nil {
 			t.Fatalf("PutBucketPolicy failed: %v", err)
 		}
 

--- a/internal/handler/bucket.go
+++ b/internal/handler/bucket.go
@@ -85,8 +85,8 @@ var (
 	getBucketPolicyFn = func(h *Handler, bucketName string) (string, error) {
 		return h.backend.GetBucketPolicy(bucketName)
 	}
-	putBucketPolicyFn = func(h *Handler, bucketName, policy string) error {
-		return h.backend.PutBucketPolicy(bucketName, policy)
+	putBucketPolicyFn = func(h *Handler, bucketName, policy string, denySelfAccess bool) error {
+		return h.backend.PutBucketPolicy(bucketName, policy, denySelfAccess)
 	}
 	deleteBucketPolicyFn = func(h *Handler, bucketName string) error {
 		return h.backend.DeleteBucketPolicy(bucketName)
@@ -2047,7 +2047,11 @@ func (h *Handler) handlePutBucketPolicy(
 		return
 	}
 
-	err = putBucketPolicyFn(h, bucketName, string(body))
+	denySelfAccess := strings.EqualFold(
+		headerValueAnyCase(r.Header, "x-amz-confirm-remove-self-bucket-access"), "true",
+	)
+
+	err = putBucketPolicyFn(h, bucketName, string(body), denySelfAccess)
 	if err != nil {
 		if errors.Is(err, backend.ErrBucketNotFound) {
 			backend.WriteError(

--- a/internal/handler/bucket_uncovered_branches_test.go
+++ b/internal/handler/bucket_uncovered_branches_test.go
@@ -765,7 +765,7 @@ func TestBucketListVersioningAndConfigInternalBranches(t *testing.T) {
 		getBucketPolicyFn = origGetPolicy
 
 		origPutPolicy := putBucketPolicyFn
-		putBucketPolicyFn = func(*Handler, string, string) error { return errors.New("policy put boom") }
+		putBucketPolicyFn = func(*Handler, string, string, bool) error { return errors.New("policy put boom") }
 		wPutPolicy := doRequest(
 			h,
 			newRequest(

--- a/internal/handler/iam_test.go
+++ b/internal/handler/iam_test.go
@@ -1,0 +1,358 @@
+package handler
+
+import (
+	"encoding/xml"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestIAMCreateUserAndAccessKey(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	rootHeaders := map[string]string{"Authorization": authHeader("root-access-key")}
+
+	// CreateUser via POST form
+	wCreate := doRequest(h, newRequest(
+		http.MethodPost, "http://example.test/",
+		"Action=CreateUser&UserName=testiam&Path=/s3-tests/",
+		map[string]string{
+			"Content-Type":  "application/x-www-form-urlencoded",
+			"Authorization": authHeader("root-access-key"),
+		},
+	))
+	requireStatus(t, wCreate, http.StatusCreated)
+	if !strings.Contains(wCreate.Body.String(), "<UserName>testiam</UserName>") {
+		t.Fatalf("CreateUser response missing UserName: %s", wCreate.Body.String())
+	}
+
+	// CreateAccessKey
+	wKey := doRequest(h, newRequest(
+		http.MethodPost, "http://example.test/",
+		"Action=CreateAccessKey&UserName=testiam",
+		map[string]string{
+			"Content-Type":  "application/x-www-form-urlencoded",
+			"Authorization": authHeader("root-access-key"),
+		},
+	))
+	requireStatus(t, wKey, http.StatusCreated)
+	body := wKey.Body.String()
+	if !strings.Contains(body, "<AccessKeyId>") {
+		t.Fatalf("CreateAccessKey response missing AccessKeyId: %s", body)
+	}
+	if !strings.Contains(body, "<SecretAccessKey>") {
+		t.Fatalf("CreateAccessKey response missing SecretAccessKey: %s", body)
+	}
+
+	// Extract the access key from response
+	type accessKeyResp struct {
+		XMLName xml.Name `xml:"CreateAccessKeyResponse"`
+		Result  struct {
+			AccessKey struct {
+				AccessKeyId     string `xml:"AccessKeyId"`
+				SecretAccessKey string `xml:"SecretAccessKey"`
+			} `xml:"AccessKey"`
+		} `xml:"CreateAccessKeyResult"`
+	}
+	var akr accessKeyResp
+	if err := xml.Unmarshal(wKey.Body.Bytes(), &akr); err != nil {
+		t.Fatalf("failed to parse CreateAccessKey response: %v", err)
+	}
+
+	// The newly created access key should be usable for auth
+	// (we verify the credential lookup works)
+	secret, ok := credentialLookupFn(akr.Result.AccessKey.AccessKeyId)
+	if !ok {
+		t.Fatal("newly created access key should be found in credential lookup")
+	}
+	if secret != akr.Result.AccessKey.SecretAccessKey {
+		t.Fatal("secret key mismatch")
+	}
+
+	// ListUsers
+	wList := doRequest(h, newRequest(
+		http.MethodGet, "http://example.test/?Action=ListUsers&PathPrefix=/s3-tests/",
+		"", rootHeaders,
+	))
+	requireStatus(t, wList, http.StatusOK)
+	if !strings.Contains(wList.Body.String(), "<UserName>testiam</UserName>") {
+		t.Fatalf("ListUsers should contain testiam: %s", wList.Body.String())
+	}
+
+	// ListAccessKeys
+	wListKeys := doRequest(h, newRequest(
+		http.MethodGet, "http://example.test/?Action=ListAccessKeys&UserName=testiam",
+		"", rootHeaders,
+	))
+	requireStatus(t, wListKeys, http.StatusOK)
+	if !strings.Contains(wListKeys.Body.String(), akr.Result.AccessKey.AccessKeyId) {
+		t.Fatalf("ListAccessKeys should contain the key: %s", wListKeys.Body.String())
+	}
+
+	// DeleteAccessKey
+	wDelKey := doRequest(h, newRequest(
+		http.MethodPost, "http://example.test/",
+		"Action=DeleteAccessKey&UserName=testiam&AccessKeyId="+akr.Result.AccessKey.AccessKeyId,
+		map[string]string{
+			"Content-Type":  "application/x-www-form-urlencoded",
+			"Authorization": authHeader("root-access-key"),
+		},
+	))
+	requireStatus(t, wDelKey, http.StatusOK)
+
+	// DeleteUser
+	wDelUser := doRequest(h, newRequest(
+		http.MethodPost, "http://example.test/",
+		"Action=DeleteUser&UserName=testiam",
+		map[string]string{
+			"Content-Type":  "application/x-www-form-urlencoded",
+			"Authorization": authHeader("root-access-key"),
+		},
+	))
+	requireStatus(t, wDelUser, http.StatusOK)
+}
+
+func TestIAMStubActions(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	rootHeaders := map[string]string{"Authorization": authHeader("root-access-key")}
+
+	stubs := []struct {
+		action   string
+		contains string
+	}{
+		{"ListUserPolicies", "ListUserPoliciesResponse"},
+		{"ListAttachedUserPolicies", "ListAttachedUserPoliciesResponse"},
+		{"ListGroups", "ListGroupsResponse"},
+		{"ListRoles", "ListRolesResponse"},
+		{"ListOpenIDConnectProviders", "ListOpenIDConnectProvidersResponse"},
+	}
+
+	for _, s := range stubs {
+		t.Run(s.action, func(t *testing.T) {
+			w := doRequest(h, newRequest(
+				http.MethodGet,
+				"http://example.test/?Action="+s.action,
+				"", rootHeaders,
+			))
+			requireStatus(t, w, http.StatusOK)
+			if !strings.Contains(w.Body.String(), s.contains) {
+				t.Fatalf("expected %s in body: %s", s.contains, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestIAMCreateUserConflict(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	// Create user first time
+	doRequest(h, newRequest(
+		http.MethodPost, "http://example.test/",
+		"Action=CreateUser&UserName=dup",
+		map[string]string{
+			"Content-Type":  "application/x-www-form-urlencoded",
+			"Authorization": authHeader("root-access-key"),
+		},
+	))
+
+	// Second time should conflict
+	w := doRequest(h, newRequest(
+		http.MethodPost, "http://example.test/",
+		"Action=CreateUser&UserName=dup",
+		map[string]string{
+			"Content-Type":  "application/x-www-form-urlencoded",
+			"Authorization": authHeader("root-access-key"),
+		},
+	))
+	requireStatus(t, w, http.StatusConflict)
+}
+
+func TestIAMCreateAccessKeyUserNotFound(t *testing.T) {
+	h, _ := newTestHandler(t)
+
+	w := doRequest(h, newRequest(
+		http.MethodPost, "http://example.test/",
+		"Action=CreateAccessKey&UserName=nonexistent",
+		map[string]string{
+			"Content-Type":  "application/x-www-form-urlencoded",
+			"Authorization": authHeader("root-access-key"),
+		},
+	))
+	requireStatus(t, w, http.StatusNotFound)
+}
+
+func TestBucketPolicyDenySelfE2E(t *testing.T) {
+	h, b := newTestHandler(t)
+	mustCreateBucket(t, b, "deny-self-bucket")
+	b.SetBucketOwner("deny-self-bucket", "root-access-key")
+
+	ownerHeaders := map[string]string{"Authorization": authHeader("root-access-key")}
+	altHeaders := map[string]string{"Authorization": authHeader("minis3-alt-access-key")}
+
+	denyPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":"*","Action":["s3:PutBucketPolicy","s3:GetBucketPolicy","s3:DeleteBucketPolicy"],"Resource":["arn:aws:s3:::deny-self-bucket","arn:aws:s3:::deny-self-bucket/*"]}]}`
+
+	// Put policy without ConfirmRemoveSelfBucketAccess
+	wPut := doRequest(h, newRequest(
+		http.MethodPut,
+		"http://example.test/deny-self-bucket?policy",
+		denyPolicy,
+		ownerHeaders,
+	))
+	requireStatus(t, wPut, http.StatusNoContent)
+
+	t.Run("non-owner denied", func(t *testing.T) {
+		w := doRequest(h, newRequest(
+			http.MethodGet, "http://example.test/deny-self-bucket?policy", "", altHeaders,
+		))
+		requireStatus(t, w, http.StatusForbidden)
+		requireS3ErrorCode(t, w, "AccessDenied")
+	})
+
+	t.Run("owner allowed (no confirm header)", func(t *testing.T) {
+		w := doRequest(h, newRequest(
+			http.MethodGet, "http://example.test/deny-self-bucket?policy", "", ownerHeaders,
+		))
+		requireStatus(t, w, http.StatusOK)
+	})
+
+	t.Run("owner can delete policy", func(t *testing.T) {
+		w := doRequest(h, newRequest(
+			http.MethodDelete, "http://example.test/deny-self-bucket?policy", "", ownerHeaders,
+		))
+		requireStatus(t, w, http.StatusNoContent)
+	})
+
+	t.Run("owner can re-put policy", func(t *testing.T) {
+		w := doRequest(h, newRequest(
+			http.MethodPut,
+			"http://example.test/deny-self-bucket?policy",
+			denyPolicy,
+			ownerHeaders,
+		))
+		requireStatus(t, w, http.StatusNoContent)
+	})
+
+	// Now put with ConfirmRemoveSelfBucketAccess header
+	t.Run("with ConfirmRemoveSelfBucketAccess", func(t *testing.T) {
+		wConfirm := doRequest(h, newRequest(
+			http.MethodPut,
+			"http://example.test/deny-self-bucket?policy",
+			denyPolicy,
+			map[string]string{
+				"Authorization": authHeader("root-access-key"),
+				"x-amz-confirm-remove-self-bucket-access": "true",
+			},
+		))
+		requireStatus(t, wConfirm, http.StatusNoContent)
+
+		// Owner should now be denied too
+		wGet := doRequest(h, newRequest(
+			http.MethodGet, "http://example.test/deny-self-bucket?policy", "", ownerHeaders,
+		))
+		requireStatus(t, wGet, http.StatusForbidden)
+		requireS3ErrorCode(t, wGet, "AccessDenied")
+
+		wDel := doRequest(h, newRequest(
+			http.MethodDelete, "http://example.test/deny-self-bucket?policy", "", ownerHeaders,
+		))
+		requireStatus(t, wDel, http.StatusForbidden)
+		requireS3ErrorCode(t, wDel, "AccessDenied")
+
+		wPut := doRequest(h, newRequest(
+			http.MethodPut,
+			"http://example.test/deny-self-bucket?policy",
+			denyPolicy,
+			ownerHeaders,
+		))
+		requireStatus(t, wPut, http.StatusForbidden)
+		requireS3ErrorCode(t, wPut, "AccessDenied")
+	})
+}
+
+func TestBucketPolicyDenySelfWithIAMUser(t *testing.T) {
+	h, b := newTestHandler(t)
+	mustCreateBucket(t, b, "iam-deny-bucket")
+	b.SetBucketOwner("iam-deny-bucket", "root-access-key")
+
+	ownerHeaders := map[string]string{"Authorization": authHeader("root-access-key")}
+
+	// Create IAM user via handler
+	doRequest(h, newRequest(
+		http.MethodPost, "http://example.test/",
+		"Action=CreateUser&UserName=iamtestuser&Path=/s3-tests/",
+		map[string]string{
+			"Content-Type":  "application/x-www-form-urlencoded",
+			"Authorization": authHeader("root-access-key"),
+		},
+	))
+
+	wKey := doRequest(h, newRequest(
+		http.MethodPost, "http://example.test/",
+		"Action=CreateAccessKey&UserName=iamtestuser",
+		map[string]string{
+			"Content-Type":  "application/x-www-form-urlencoded",
+			"Authorization": authHeader("root-access-key"),
+		},
+	))
+
+	type akResp struct {
+		XMLName xml.Name `xml:"CreateAccessKeyResponse"`
+		Result  struct {
+			AccessKey struct {
+				AccessKeyId string `xml:"AccessKeyId"`
+			} `xml:"AccessKey"`
+		} `xml:"CreateAccessKeyResult"`
+	}
+	var akr akResp
+	_ = xml.Unmarshal(wKey.Body.Bytes(), &akr)
+
+	iamUserHeaders := map[string]string{
+		"Authorization": "AWS " + akr.Result.AccessKey.AccessKeyId + ":sig",
+	}
+
+	denyPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Principal":"*","Action":["s3:PutBucketPolicy","s3:GetBucketPolicy","s3:DeleteBucketPolicy"],"Resource":["arn:aws:s3:::iam-deny-bucket","arn:aws:s3:::iam-deny-bucket/*"]}]}`
+
+	// Set deny policy without confirm header
+	wPut := doRequest(h, newRequest(
+		http.MethodPut,
+		"http://example.test/iam-deny-bucket?policy",
+		denyPolicy,
+		ownerHeaders,
+	))
+	requireStatus(t, wPut, http.StatusNoContent)
+
+	// IAM user (not owner) should be denied
+	wIAMGet := doRequest(h, newRequest(
+		http.MethodGet, "http://example.test/iam-deny-bucket?policy", "", iamUserHeaders,
+	))
+	requireStatus(t, wIAMGet, http.StatusForbidden)
+
+	// Owner should still have access
+	wOwnerGet := doRequest(h, newRequest(
+		http.MethodGet, "http://example.test/iam-deny-bucket?policy", "", ownerHeaders,
+	))
+	requireStatus(t, wOwnerGet, http.StatusOK)
+}
+
+func TestIsBucketPolicyAction(t *testing.T) {
+	tests := []struct {
+		action string
+		want   bool
+	}{
+		{"s3:GetBucketPolicy", true},
+		{"s3:PutBucketPolicy", true},
+		{"s3:DeleteBucketPolicy", true},
+		{"s3:GetObject", false},
+		{"s3:PutObject", false},
+		{"s3:ListBucket", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.action, func(t *testing.T) {
+			if got := isBucketPolicyAction(tc.action); got != tc.want {
+				t.Fatalf("isBucketPolicyAction(%q) = %v, want %v", tc.action, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/handler/io_xml_hook_branches_test.go
+++ b/internal/handler/io_xml_hook_branches_test.go
@@ -191,6 +191,7 @@ func TestXMLMarshalErrorHookBranches(t *testing.T) {
 	if err := b.PutBucketPolicy(
 		"marshal-bucket",
 		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::marshal-bucket/*"}]}`,
+		false,
 	); err != nil {
 		t.Fatalf("PutBucketPolicy failed: %v", err)
 	}

--- a/internal/handler/new_coverage_logging_test.go
+++ b/internal/handler/new_coverage_logging_test.go
@@ -14,7 +14,7 @@ import (
 
 func mustPutBucketPolicy(t *testing.T, b *backend.Backend, bucketName, policy string) {
 	t.Helper()
-	if err := b.PutBucketPolicy(bucketName, policy); err != nil {
+	if err := b.PutBucketPolicy(bucketName, policy, false); err != nil {
 		t.Fatalf("PutBucketPolicy(%q) failed: %v", bucketName, err)
 	}
 }
@@ -342,7 +342,7 @@ func TestBucketLoggingOwnershipAndRequestPaymentBranches(t *testing.T) {
 		requireS3ErrorCode(t, wMissingTarget, "NoSuchKey")
 
 		// No policy on target -> AccessDenied from bucketLoggingTargetAllowed.
-		if err := b.PutBucketPolicy("dst-log", `{"Version":"2012-10-17","Statement":[]}`); err != nil {
+		if err := b.PutBucketPolicy("dst-log", `{"Version":"2012-10-17","Statement":[]}`, false); err != nil {
 			t.Fatalf("PutBucketPolicy reset failed: %v", err)
 		}
 		wDeniedPolicy := doRequest(

--- a/internal/handler/object_access_test.go
+++ b/internal/handler/object_access_test.go
@@ -278,7 +278,7 @@ func TestCheckAccessPolicyEvaluation(t *testing.T) {
 
 	t.Run("explicit deny blocks even owner", func(t *testing.T) {
 		policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Action":"s3:GetObject","Resource":"arn:aws:s3:::policy-bucket/*"}]}`
-		if err := b.PutBucketPolicy("policy-bucket", policy); err != nil {
+		if err := b.PutBucketPolicy("policy-bucket", policy, false); err != nil {
 			t.Fatalf("PutBucketPolicy failed: %v", err)
 		}
 
@@ -291,7 +291,7 @@ func TestCheckAccessPolicyEvaluation(t *testing.T) {
 
 	t.Run("allow permits non-owner", func(t *testing.T) {
 		policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::policy-bucket/*"}]}`
-		if err := b.PutBucketPolicy("policy-bucket", policy); err != nil {
+		if err := b.PutBucketPolicy("policy-bucket", policy, false); err != nil {
 			t.Fatalf("PutBucketPolicy failed: %v", err)
 		}
 
@@ -312,7 +312,7 @@ func TestCheckAccessWithContextUsesObjectTags(t *testing.T) {
 	h := New(b)
 
 	policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Resource":"arn:aws:s3:::policy-context-bucket/*","Condition":{"StringEquals":{"s3:ExistingObjectTag/Project":"alpha"}}}]}`
-	if err := b.PutBucketPolicy("policy-context-bucket", policy); err != nil {
+	if err := b.PutBucketPolicy("policy-context-bucket", policy, false); err != nil {
 		t.Fatalf("PutBucketPolicy failed: %v", err)
 	}
 
@@ -370,7 +370,7 @@ func TestCheckAccessWithContextStringLikeIfExistsRefererMismatch(t *testing.T) {
 	h := New(b)
 
 	policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"s3:GetObject","Principal":"*","Resource":"arn:aws:s3:::policy-referer-bucket/*","Condition":{"StringLikeIfExists":{"aws:Referer":"http://www.example.com/*"}}}]}`
-	if err := b.PutBucketPolicy("policy-referer-bucket", policy); err != nil {
+	if err := b.PutBucketPolicy("policy-referer-bucket", policy, false); err != nil {
 		t.Fatalf("PutBucketPolicy failed: %v", err)
 	}
 

--- a/internal/handler/post_bucket_logging_test.go
+++ b/internal/handler/post_bucket_logging_test.go
@@ -19,7 +19,7 @@ func TestPostBucketLoggingFlush(t *testing.T) {
 
 	// Set target bucket policy to allow logging service writes
 	tgtPolicy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"logging.s3.amazonaws.com"},"Action":"s3:PutObject","Resource":"arn:aws:s3:::tgt-log/*"}]}`
-	if err := b.PutBucketPolicy("tgt-log", tgtPolicy); err != nil {
+	if err := b.PutBucketPolicy("tgt-log", tgtPolicy, false); err != nil {
 		t.Fatalf("PutBucketPolicy failed: %v", err)
 	}
 

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -17,7 +17,7 @@ tasks:
     cmds:
       - task: unit-test
       - task: sdk-test
-      # - task: s3-test
+      - task: s3-test
 
   unit-test:
     desc: "Unit test"


### PR DESCRIPTION
- Introduced IAMUser and IAMAccessKey structs for managing IAM users and their access keys.
- Implemented CreateIAMUser and CreateIAMAccessKey methods for user and key creation.
- Added DeleteIAMUser and DeleteIAMAccessKey methods for user and key deletion.
- Enhanced bucket policy management to include a deny self-access feature.
- Updated tests to cover new IAM functionalities and policy management changes.